### PR TITLE
remove watch timeout to allow call staggering

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	k8s.io/api v0.29.0
 	k8s.io/apimachinery v0.29.0
-	k8s.io/client-go v1.5.2
+	k8s.io/client-go v0.29.0
 	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.110.1
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect

--- a/pkg/k8sclient/k8sclient.go
+++ b/pkg/k8sclient/k8sclient.go
@@ -59,7 +59,9 @@ type NoK8sNetworkError struct {
 // ClientInfo contains information given from k8s client
 type ClientInfo struct {
 	Client           kubernetes.Interface
+	WatchClient      kubernetes.Interface
 	NetClient        netclient.Interface
+	NetWatchClient   netclient.Interface
 	EventBroadcaster record.EventBroadcaster
 	EventRecorder    record.EventRecorder
 

--- a/pkg/multus/multus_cni100_test.go
+++ b/pkg/multus/multus_cni100_test.go
@@ -48,8 +48,8 @@ import (
 	netdefinformerv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/informers/externalversions/k8s.cni.cncf.io/v1"
 )
 
-func newPodInformer(ctx context.Context, kclient kubernetes.Interface) cache.SharedIndexInformer {
-	informerFactory := informerfactory.NewSharedInformerFactory(kclient, 0*time.Second)
+func newPodInformer(ctx context.Context, watchClient kubernetes.Interface) cache.SharedIndexInformer {
+	informerFactory := informerfactory.NewSharedInformerFactory(watchClient, 0*time.Second)
 
 	podInformer := informerFactory.InformerFor(&kapi.Pod{}, func(c kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
 		return v1coreinformers.NewFilteredPodInformer(
@@ -71,8 +71,8 @@ func newPodInformer(ctx context.Context, kclient kubernetes.Interface) cache.Sha
 	return podInformer
 }
 
-func newNetDefInformer(ctx context.Context, client netdefclient.Interface) cache.SharedIndexInformer {
-	informerFactory := netdefinformer.NewSharedInformerFactory(client, 0*time.Second)
+func newNetDefInformer(ctx context.Context, netWatchClient netdefclient.Interface) cache.SharedIndexInformer {
+	informerFactory := netdefinformer.NewSharedInformerFactory(netWatchClient, 0*time.Second)
 
 	netdefInformer := informerFactory.InformerFor(&netdefv1.NetworkAttachmentDefinition{}, func(client netdefclient.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
 		return netdefinformerv1.NewNetworkAttachmentDefinitionInformer(
@@ -941,8 +941,8 @@ var _ = Describe("multus operations cniVersion 1.0.0 config", func() {
 		_, err := fKubeClient.AddNetAttachDef(testhelpers.NewFakeNetAttachDef("kube-system", "net1", net1))
 		Expect(err).NotTo(HaveOccurred())
 
-		podInformer := newPodInformer(ctx, fKubeClient.Client)
-		netdefInformer := newNetDefInformer(ctx, fKubeClient.NetClient)
+		podInformer := newPodInformer(ctx, fKubeClient.WatchClient)
+		netdefInformer := newNetDefInformer(ctx, fKubeClient.NetWatchClient)
 		fKubeClient.SetK8sClientInformers(podInformer, netdefInformer)
 
 		result, err := CmdAdd(args, fExec, fKubeClient)
@@ -991,8 +991,8 @@ var _ = Describe("multus operations cniVersion 1.0.0 config", func() {
 		_, err := fKubeClient.AddNetAttachDef(testhelpers.NewFakeNetAttachDef("kube-system", "net1", net1))
 		Expect(err).NotTo(HaveOccurred())
 
-		podInformer := newPodInformer(ctx, fKubeClient.Client)
-		netdefInformer := newNetDefInformer(ctx, fKubeClient.NetClient)
+		podInformer := newPodInformer(ctx, fKubeClient.WatchClient)
+		netdefInformer := newNetDefInformer(ctx, fKubeClient.NetWatchClient)
 		fKubeClient.SetK8sClientInformers(podInformer, netdefInformer)
 
 		wg := sync.WaitGroup{}

--- a/pkg/multus/multus_suite_test.go
+++ b/pkg/multus/multus_suite_test.go
@@ -225,9 +225,11 @@ func (f *fakeExec) FindInPath(plugin string, paths []string) (string, error) {
 // NewFakeClientInfo returns fake client (just for testing)
 func NewFakeClientInfo() *k8sclient.ClientInfo {
 	return &k8sclient.ClientInfo{
-		Client:        fake.NewSimpleClientset(),
-		NetClient:     netfake.NewSimpleClientset(),
-		EventRecorder: record.NewFakeRecorder(10),
+		Client:         fake.NewSimpleClientset(),
+		WatchClient:    fake.NewSimpleClientset(),
+		NetClient:      netfake.NewSimpleClientset(),
+		NetWatchClient: netfake.NewSimpleClientset(),
+		EventRecorder:  record.NewFakeRecorder(10),
 	}
 }
 

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -54,7 +54,7 @@ type Server struct {
 	exec                  invoke.Exec
 	serverConfig          []byte
 	metrics               *Metrics
-	informerFactory       internalinterfaces.SharedInformerFactory
+	podInformerFactory    internalinterfaces.SharedInformerFactory
 	podInformer           cache.SharedIndexInformer
 	netdefInformerFactory netdefinformer.SharedInformerFactory
 	netdefInformer        cache.SharedIndexInformer

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -478,7 +478,7 @@ k8s.io/apimachinery/pkg/version
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/reflect
-# k8s.io/client-go v1.5.2 => k8s.io/client-go v0.29.0
+# k8s.io/client-go v0.29.0
 ## explicit; go 1.21
 k8s.io/client-go/applyconfigurations/admissionregistration/v1
 k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1


### PR DESCRIPTION
The watch calls from multus were reconnecting to the API server every minute, due to a one-minute timeout specified on the rest config. Reconnecting every minute imposes unnecessary load on the api server and watches with fixed timeouts won't be temporally staggered to make the api server load even. For watch calls, we should completely delegate the reconnections to client-go. Watches from other components (kubelet, kube-scheduler, cilium) are doing this delegation already.

Reference: https://github.com/kubernetes/client-go/blob/03443e7ede0e50d195b8669103ce082e735c6b94/tools/cache/reflector.go#L52-L56

Pod watch:
```
// prior to this change
2024-06-07T17:49:38.929150Z -> 2024-06-07T17:50:38.929483Z -> multus-daemon/v0.0.0 (linux/amd64) kubernetes/$Format -> watch -> /api/v1/pods?allowWatchBookmarks=true&fieldSelector=spec.nodeName%3Dpytest-ci-1717689938-worker&resourceVersion=312906&timeout=8m14s&timeoutSeconds=494&watch=true -> 200
2024-06-07T17:50:38.929684Z -> 2024-06-07T17:51:38.930434Z -> multus-daemon/v0.0.0 (linux/amd64) kubernetes/$Format -> watch -> /api/v1/pods?allowWatchBookmarks=true&fieldSelector=spec.nodeName%3Dpytest-ci-1717689938-worker&resourceVersion=312906&timeout=9m12s&timeoutSeconds=552&watch=true -> 200

// with this change
2024-06-12T03:44:13.024297Z -> 2024-06-12T03:53:26.025634Z -> multus-daemon/v0.0.0 (linux/amd64) kubernetes/$Format -> watch -> /api/v1/pods?allowWatchBookmarks=true&fieldSelector=spec.nodeName%3Dpytest-ci-1718094202-worker&resourceVersion=219877&timeout=9m13s&timeoutSeconds=553&watch=true -> 200
2024-06-12T03:53:26.026164Z -> 2024-06-12T03:58:38.028134Z -> multus-daemon/v0.0.0 (linux/amd64) kubernetes/$Format -> watch -> /api/v1/pods?allowWatchBookmarks=true&fieldSelector=spec.nodeName%3Dpytest-ci-1718094202-worker&resourceVersion=219883&timeout=5m12s&timeoutSeconds=312&watch=true -> 200
```

Nad watch:
```
// prior to this change
2024-06-07T17:48:38.872269Z -> 2024-06-07T17:49:38.873034Z -> multus-daemon/v0.0.0 (linux/amd64) kubernetes/$Format -> watch -> /apis/k8s.cni.cncf.io/v1/network-attachment-definitions?allowWatchBookmarks=true&resourceVersion=310731&timeout=7m32s&timeoutSeconds=452&watch=true -> 200
2024-06-07T17:47:38.871806Z -> 2024-06-07T17:48:38.871976Z -> multus-daemon/v0.0.0 (linux/amd64) kubernetes/$Format -> watch -> /apis/k8s.cni.cncf.io/v1/network-attachment-definitions?allowWatchBookmarks=true&resourceVersion=310731&timeout=8m50s&timeoutSeconds=530&watch=true -> 200

// with this change
2024-06-12T03:52:43.026301Z -> 2024-06-12T04:01:08.034631Z -> multus-daemon/v0.0.0 (linux/amd64) kubernetes/$Format -> watch -> /apis/k8s.cni.cncf.io/v1/network-attachment-definitions?allowWatchBookmarks=true&resourceVersion=219541&timeout=8m25s&timeoutSeconds=505&watch=true -> 200
2024-06-12T03:50:48.091214Z -> 2024-06-12T03:59:52.093306Z -> multus-daemon/v0.0.0 (linux/amd64) kubernetes/$Format -> watch -> /apis/k8s.cni.cncf.io/v1/network-attachment-definitions?allowWatchBookmarks=true&resourceVersion=219541&timeout=9m4s&timeoutSeconds=544&watch=true -> 200
```